### PR TITLE
Fix 2 small bugs

### DIFF
--- a/src/update-client.cc
+++ b/src/update-client.cc
@@ -1060,6 +1060,12 @@ void update_http_request<http::dynamic_body, true>::handle_response_body(boost::
 		auto &body = response_parser.get().body();
 
 		for (auto iter = asio::buffer_sequence_begin(body.data()); iter != asio::buffer_sequence_end(body.data()); ++iter) {
+			if ((*iter).size() > asio::buffer_size(body.data())) {
+				delete file_ctx;
+				std::string msg = std::string("Failed to recieve file body correctly. for : ") + target;
+				handle_download_error(boost::asio::error::basic_errors::connection_aborted, msg);
+				return;
+			}
 			file_ctx->output_chain.write((const char *)(*iter).data(), (*iter).size());
 		}
 

--- a/src/utils.cc
+++ b/src/utils.cc
@@ -107,6 +107,9 @@ LPWSTR ConvertToUtf16LP(const char *from, int *from_size)
 bool is_system_folder(const fs::path &path)
 {
 	DWORD fileAttributes = GetFileAttributes(path.c_str());
+	if (fileAttributes == INVALID_FILE_ATTRIBUTES) {
+		return false;
+	}
 	return fileAttributes & FILE_ATTRIBUTE_SYSTEM;
 }
 


### PR DESCRIPTION
Bug #1: unhandled exception when processing a corrupted file. Before copying data, make sure the size is a valid value. Otherwise, handle as if it were an exception that was caught. 

Bug #2: if command line parsing fails, the error message displayed stated that Streamlabs was installed in a system folder. Check return value of 'GetFileAttributes' for INVALID_FILE_ATTRIBUTES when checking if it is a system folder. 