### PR TITLE
Functional changes to give user the option to update

### DIFF
--- a/src/cli-parser.cc
+++ b/src/cli-parser.cc
@@ -176,10 +176,12 @@ bool su_parse_command_line(int argc, char **argv, struct update_parameters *para
 
 	struct arg_lit *restart_arg = arg_lit0(NULL, "restart-after-fail", "Start Streamlabs Desktop after update fail with option to skip update");
 
+	struct arg_str *details_arg = arg_str1("d", "details", "<details>", "The details of the update");
+
 	struct arg_end *end_arg = arg_end(255);
 
-	void *arg_table[] = {help_arg,     dump_args_arg, force_arg, base_uri_arg,    app_dir_arg, exec_arg, cwd_arg,
-			     temp_dir_arg, version_arg,   pids_arg,  interactive_arg, restart_arg, end_arg};
+	void *arg_table[] = {help_arg,     dump_args_arg, force_arg, base_uri_arg,    app_dir_arg, exec_arg,    cwd_arg,
+			     temp_dir_arg, version_arg,   pids_arg,  interactive_arg, restart_arg, details_arg, end_arg};
 
 	const int arg_table_sz = sizeof(arg_table) / sizeof(arg_table[0]);
 
@@ -187,7 +189,7 @@ bool su_parse_command_line(int argc, char **argv, struct update_parameters *para
 
 	/* We need type information to dump parameters generically */
 	enum arg_type arg_table_types[arg_table_sz] = {ARG_LITERAL, ARG_LITERAL, ARG_LITERAL, ARG_STRING,  ARG_STRING,  ARG_STRING, ARG_STRING,
-						       ARG_STRING,  ARG_STRING,  ARG_INTEGER, ARG_INTEGER, ARG_LITERAL, ARG_END};
+						       ARG_STRING,  ARG_STRING,  ARG_INTEGER, ARG_INTEGER, ARG_LITERAL, ARG_STRING, ARG_END};
 
 	/* Here we assume that stdout is setup correctly, otherwise --help is pointless */
 	if (help_arg->count > 0) {
@@ -295,6 +297,7 @@ bool su_parse_command_line(int argc, char **argv, struct update_parameters *para
 
 	params->pids = make_vector_from_arg(pids_arg);
 	params->version.assign(version_arg->sval[0]);
+	params->details.assign(details_arg->sval[0]);
 
 	if (interactive_arg->count > 0) {
 		params->interactive = interactive_arg->ival[0];

--- a/src/cli-parser.cc
+++ b/src/cli-parser.cc
@@ -176,10 +176,12 @@ bool su_parse_command_line(int argc, char **argv, struct update_parameters *para
 
 	struct arg_lit *restart_arg = arg_lit0(NULL, "restart-after-fail", "Start Streamlabs Desktop after update fail with option to skip update");
 
+	struct arg_str *details_arg = arg_str1("d", "details", "<details>", "The details of the update");
+
 	struct arg_end *end_arg = arg_end(255);
 
 	void *arg_table[] = {help_arg,     dump_args_arg, force_arg, base_uri_arg,    app_dir_arg, exec_arg,    cwd_arg,
-			     temp_dir_arg, version_arg,   pids_arg,  interactive_arg, restart_arg, end_arg};
+			     temp_dir_arg, version_arg,   pids_arg,  interactive_arg, restart_arg, details_arg, end_arg};
 
 	const int arg_table_sz = sizeof(arg_table) / sizeof(arg_table[0]);
 
@@ -187,7 +189,7 @@ bool su_parse_command_line(int argc, char **argv, struct update_parameters *para
 
 	/* We need type information to dump parameters generically */
 	enum arg_type arg_table_types[arg_table_sz] = {ARG_LITERAL, ARG_LITERAL, ARG_LITERAL, ARG_STRING,  ARG_STRING,  ARG_STRING, ARG_STRING,
-						       ARG_STRING,  ARG_STRING,  ARG_INTEGER, ARG_INTEGER, ARG_LITERAL, ARG_END};
+						       ARG_STRING,  ARG_STRING,  ARG_INTEGER, ARG_INTEGER, ARG_LITERAL, ARG_STRING, ARG_END};
 
 	/* Here we assume that stdout is setup correctly, otherwise --help is pointless */
 	if (help_arg->count > 0) {
@@ -227,6 +229,14 @@ bool su_parse_command_line(int argc, char **argv, struct update_parameters *para
 
 	if (dump_args_arg->count > 0)
 		print_arg_table(arg_table, arg_table_types, arg_table_sz);
+
+	//if missing 'details' param ignore it
+	if (num_errors == 1)
+	{
+		arg_str *parent = (arg_str *)end_arg->parent[0];
+		if (strcmp(parent->hdr.shortopts, "d") == 0)
+			num_errors = 0;
+	}
 
 	if (num_errors > 0) {
 		arg_print_errors(params->log_file, end_arg, argv[0]);
@@ -295,6 +305,7 @@ bool su_parse_command_line(int argc, char **argv, struct update_parameters *para
 
 	params->pids = make_vector_from_arg(pids_arg);
 	params->version.assign(version_arg->sval[0]);
+	params->details.assign(details_arg->sval[0]);
 
 	if (interactive_arg->count > 0) {
 		params->interactive = interactive_arg->ival[0];

--- a/src/cli-parser.cc
+++ b/src/cli-parser.cc
@@ -176,12 +176,10 @@ bool su_parse_command_line(int argc, char **argv, struct update_parameters *para
 
 	struct arg_lit *restart_arg = arg_lit0(NULL, "restart-after-fail", "Start Streamlabs Desktop after update fail with option to skip update");
 
-	struct arg_str *details_arg = arg_str1("d", "details", "<details>", "The details of the update");
-
 	struct arg_end *end_arg = arg_end(255);
 
 	void *arg_table[] = {help_arg,     dump_args_arg, force_arg, base_uri_arg,    app_dir_arg, exec_arg,    cwd_arg,
-			     temp_dir_arg, version_arg,   pids_arg,  interactive_arg, restart_arg, details_arg, end_arg};
+			     temp_dir_arg, version_arg,   pids_arg,  interactive_arg, restart_arg, end_arg};
 
 	const int arg_table_sz = sizeof(arg_table) / sizeof(arg_table[0]);
 
@@ -189,7 +187,7 @@ bool su_parse_command_line(int argc, char **argv, struct update_parameters *para
 
 	/* We need type information to dump parameters generically */
 	enum arg_type arg_table_types[arg_table_sz] = {ARG_LITERAL, ARG_LITERAL, ARG_LITERAL, ARG_STRING,  ARG_STRING,  ARG_STRING, ARG_STRING,
-						       ARG_STRING,  ARG_STRING,  ARG_INTEGER, ARG_INTEGER, ARG_LITERAL, ARG_STRING, ARG_END};
+						       ARG_STRING,  ARG_STRING,  ARG_INTEGER, ARG_INTEGER, ARG_LITERAL, ARG_END};
 
 	/* Here we assume that stdout is setup correctly, otherwise --help is pointless */
 	if (help_arg->count > 0) {
@@ -297,7 +295,6 @@ bool su_parse_command_line(int argc, char **argv, struct update_parameters *para
 
 	params->pids = make_vector_from_arg(pids_arg);
 	params->version.assign(version_arg->sval[0]);
-	params->details.assign(details_arg->sval[0]);
 
 	if (interactive_arg->count > 0) {
 		params->interactive = interactive_arg->ival[0];

--- a/src/main.cc
+++ b/src/main.cc
@@ -170,7 +170,7 @@ struct callbacks_impl : public install_callbacks,
 	void update_finished(std::string &filename) final {}
 	void updater_complete() final {}
 
-	bool prompt_user(const char *pVersion, const char *pDetails);
+	bool prompt_user(const char *pVersion);
 };
 
 callbacks_impl::callbacks_impl(HINSTANCE hInstance, int nCmdShow)
@@ -775,57 +775,14 @@ void callbacks_impl::updater_start()
 	SetWindowTextW(progress_label, copying_label.c_str());
 }
 
-bool callbacks_impl::prompt_user(const char *pVersion, const char *pDetails)
+bool callbacks_impl::prompt_user(const char *pVersion)
 {
 	const wchar_t *wc_dash = L"-";
 	const wchar_t *wc_hash = L"#";
 	const wchar_t *wc_bullet = L"\r\n    \u2022 ";
 	const wchar_t *wc_break = L"\r\n  ";
 	std::wstring wc_version = ConvertToUtf16WS(boost::locale::translate(pVersion));
-	std::wstring wc_label = ConvertToUtf16WS(boost::locale::translate("There's an update available to install: "));
-	wc_label.insert(wc_label.size() - 1, wc_version); //account for null terminator
-	std::wstring wc_details = ConvertToUtf16WS(boost::locale::translate(pDetails));
-
-	//tag to heading conversion
-	std::list<std::pair<std::wstring, std::wstring>> tagsToHeadings;
-	tagsToHeadings.push_back(std::make_pair(L"#hotfixes", L"Hotfix Changes"));
-	tagsToHeadings.push_back(std::make_pair(L"#features", L"New Features"));
-	tagsToHeadings.push_back(std::make_pair(L"#generalfixes", L"General Fixes"));
-
-	//format detail string: insert 2 breaks at start -> 1 to have heading on its own line, 1 for spacing, one after heading for spacing
-	size_t replacePos = 0;
-	for (const auto &tagHeadingPair : tagsToHeadings) {
-		replacePos = wc_details.find(tagHeadingPair.first);
-		if (replacePos != std::wstring::npos) {
-			wc_details.replace(replacePos, tagHeadingPair.first.size(), tagHeadingPair.second);
-			if (replacePos != 0) {
-				wc_details.insert(replacePos, wc_break);
-				replacePos += +wcslen(wc_break);
-			}
-			wc_details.insert(replacePos, wc_break);
-			wc_details.insert(replacePos + wcslen(wc_break) + tagHeadingPair.second.size(), wc_break);
-		}
-	}
-	//if # isn't followed by a known heading, leave as-is to display custom heading
-	int endHeading = 0;
-	replacePos = wc_details.find(wc_hash);
-	while (replacePos != std::wstring::npos) {
-		wc_details.insert(replacePos, wc_break);
-		wc_details.replace(replacePos + wcslen(wc_break), wcslen(wc_hash), wc_break);
-		endHeading = wc_details.find(wc_dash, replacePos);
-		if (endHeading != std::wstring::npos) {
-			wc_details.insert(endHeading, wc_break);
-		}
-		replacePos = wc_details.find(wc_hash, replacePos + wcslen(wc_break));
-	}
-	//replace '-' with end line + spacing + bullet + spacing
-	replacePos = wc_details.find(wc_dash);
-	while (replacePos != std::wstring::npos) {
-		wc_details.replace(replacePos, wcslen(wc_dash), wc_bullet);
-		replacePos = wc_details.find(wc_dash, replacePos + wcslen(wc_bullet));
-	}
-	//line break at end to look nicer
-	wc_details.insert(wc_details.length(), wc_break);
+	std::wstring wc_label = ConvertToUtf16WS(boost::locale::translate("There's an update available. Would you like to install?"));
 
 	prompting = true;
 	ShowWindow(frame, SW_SHOWNORMAL);
@@ -836,7 +793,7 @@ bool callbacks_impl::prompt_user(const char *pVersion, const char *pDetails)
 	DrawText(hdc, wc_label.c_str(), -1, &progress_label_rect, DT_CALCRECT | DT_NOCLIP);
 	progress_label_rect.right -= progress_label_rect.left;
 	blockers_list_rect = {0};
-	DrawText(hdc, wc_details.c_str(), -1, &blockers_list_rect, DT_CALCRECT | DT_NOCLIP | DT_EDITCONTROL);
+	DrawText(hdc, wc_version.c_str(), -1, &blockers_list_rect, DT_CALCRECT | DT_NOCLIP | DT_EDITCONTROL);
 
 	ReleaseDC(frame, hdc);
 	SelectObject(hdc, hfontOld);
@@ -847,7 +804,7 @@ bool callbacks_impl::prompt_user(const char *pVersion, const char *pDetails)
 	repostionUI();
 
 	SetWindowTextW(progress_label, wc_label.c_str());
-	SetWindowTextW(blockers_list, wc_details.c_str());
+	SetWindowTextW(blockers_list, wc_version.c_str());
 	SetWindowTextW(continue_button, update_btn_label.c_str());
 	SetWindowTextW(cancel_button, remind_btn_label.c_str());
 
@@ -1075,7 +1032,7 @@ extern "C" int wWinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPWSTR lpC
 		return 0;
 	}
 
-	if (!cb_impl.prompt_user(params.version.c_str(), params.details.c_str())) {
+	if (!cb_impl.prompt_user(params.version.c_str())) {
 		handle_exit();
 		return 1;
 	}

--- a/src/main.cc
+++ b/src/main.cc
@@ -794,7 +794,7 @@ bool callbacks_impl::prompt_user(const char *pVersion, const char *pDetails)
 
 	//format detail string: insert 2 breaks at start -> 1 to have heading on its own line, 1 for spacing, one after heading for spacing
 	size_t replacePos = 0;
-	for (auto tagHeadingPair : tagsToHeadings) {
+	for (const auto &tagHeadingPair : tagsToHeadings) {
 		replacePos = wc_details.find(tagHeadingPair.first);
 		if (replacePos != std::wstring::npos) {
 			wc_details.replace(replacePos, tagHeadingPair.first.size(), tagHeadingPair.second);

--- a/src/main.cc
+++ b/src/main.cc
@@ -170,7 +170,7 @@ struct callbacks_impl : public install_callbacks,
 	void update_finished(std::string &filename) final {}
 	void updater_complete() final {}
 
-	bool prompt_user(const char *pVersion);
+	bool prompt_user(const char *pVersion, const char *pDetails);
 };
 
 callbacks_impl::callbacks_impl(HINSTANCE hInstance, int nCmdShow)
@@ -325,6 +325,10 @@ void callbacks_impl::repostionUI()
 	frame_h += progress_label_rect.bottom + ui_padding;
 
 	if (IsWindowVisible(blockers_list)) {
+		//if blockers_list has so much text that it exceeds screen height, readjust so it's not more than 75% of screen height
+		if ((frame_h + blockers_list_rect.bottom) > screen_height) {
+			blockers_list_rect.bottom -= ((frame_h + blockers_list_rect.bottom) - static_cast<int>(ceil(screen_height * 0.75)));
+		}
 		SetWindowPos(blockers_list, 0, ui_padding, frame_h, main_w, blockers_list_rect.bottom, SWP_ASYNCWINDOWPOS);
 		frame_h += blockers_list_rect.bottom + ui_padding;
 	}
@@ -351,7 +355,8 @@ void callbacks_impl::repostionUI()
 
 	frame_h += (winRect.bottom - winRect.top) - clientRect.bottom;
 	frame_w += (winRect.right - winRect.left) - clientRect.right;
-	SetWindowPos(frame, 0, 0, 0, frame_w, frame_h, SWP_NOMOVE | SWP_NOREPOSITION | SWP_ASYNCWINDOWPOS);
+	//adjust window to the middle of the screen
+	SetWindowPos(frame, 0, (screen_width - frame_w) / 2, (screen_height - frame_h) / 2, frame_w, frame_h, SWP_NOREPOSITION | SWP_ASYNCWINDOWPOS);
 }
 
 callbacks_impl::~callbacks_impl() {}
@@ -775,14 +780,66 @@ void callbacks_impl::updater_start()
 	SetWindowTextW(progress_label, copying_label.c_str());
 }
 
-bool callbacks_impl::prompt_user(const char *pVersion)
+bool callbacks_impl::prompt_user(const char *pVersion, const char *pDetails)
 {
 	const wchar_t *wc_dash = L"-";
 	const wchar_t *wc_hash = L"#";
 	const wchar_t *wc_bullet = L"\r\n    \u2022 ";
 	const wchar_t *wc_break = L"\r\n  ";
 	std::wstring wc_version = ConvertToUtf16WS(boost::locale::translate(pVersion));
-	std::wstring wc_label = ConvertToUtf16WS(boost::locale::translate("There's an update available. Would you like to install?"));
+
+	//handle missing details
+	std::wstring wc_label = L"";
+	std::wstring wc_details = L"New version: "; 
+	if (strlen(pDetails) == 0) {
+		wc_label = ConvertToUtf16WS(boost::locale::translate("There's an update available. Would you like to install?"));
+		wc_details.append(wc_version.c_str());
+	} else {
+		wc_label = ConvertToUtf16WS(boost::locale::translate("There's an update available to install: "));
+		wc_label.insert(wc_label.size() - 1, wc_version); //account for null terminator
+		wc_details = ConvertToUtf16WS(boost::locale::translate(pDetails));
+
+		//tag to heading conversion
+		std::list<std::pair<std::wstring, std::wstring>> tagsToHeadings;
+		tagsToHeadings.push_back(std::make_pair(L"#hotfixes", L"Hotfix Changes"));
+		tagsToHeadings.push_back(std::make_pair(L"#features", L"New Features"));
+		tagsToHeadings.push_back(std::make_pair(L"#generalfixes", L"General Fixes"));
+
+		//format detail string: insert 2 breaks at start -> 1 to have heading on its own line, 1 for spacing, one after heading for spacing
+		size_t replacePos = 0;
+		for (const auto &tagHeadingPair : tagsToHeadings) {
+			replacePos = wc_details.find(tagHeadingPair.first);
+			if (replacePos != std::wstring::npos) {
+				wc_details.replace(replacePos, tagHeadingPair.first.size(), tagHeadingPair.second);
+				if (replacePos != 0) {
+					wc_details.insert(replacePos, wc_break);
+					replacePos += +wcslen(wc_break);
+				}
+				wc_details.insert(replacePos, wc_break);
+				wc_details.insert(replacePos + wcslen(wc_break) + tagHeadingPair.second.size(), wc_break);
+			}
+		}
+		//if # isn't followed by a known heading, leave as-is to display custom heading
+		int endHeading = 0;
+		replacePos = wc_details.find(wc_hash);
+		while (replacePos != std::wstring::npos) {
+			wc_details.insert(replacePos, wc_break);
+			wc_details.replace(replacePos + wcslen(wc_break), wcslen(wc_hash), wc_break);
+			endHeading = wc_details.find(wc_dash, replacePos);
+			if (endHeading != std::wstring::npos) {
+				wc_details.insert(endHeading, wc_break);
+			}
+			replacePos = wc_details.find(wc_hash, replacePos + wcslen(wc_break));
+		}
+		//replace '-' with end line + spacing + bullet + spacing
+		replacePos = wc_details.find(wc_dash);
+		while (replacePos != std::wstring::npos) {
+			wc_details.replace(replacePos, wcslen(wc_dash), wc_bullet);
+			replacePos = wc_details.find(wc_dash, replacePos + wcslen(wc_bullet));
+		}
+		//line break at end to look nicer
+		wc_details.insert(wc_details.length(), wc_break);
+	}
 
 	prompting = true;
 	ShowWindow(frame, SW_SHOWNORMAL);
@@ -793,7 +850,7 @@ bool callbacks_impl::prompt_user(const char *pVersion)
 	DrawText(hdc, wc_label.c_str(), -1, &progress_label_rect, DT_CALCRECT | DT_NOCLIP);
 	progress_label_rect.right -= progress_label_rect.left;
 	blockers_list_rect = {0};
-	DrawText(hdc, wc_version.c_str(), -1, &blockers_list_rect, DT_CALCRECT | DT_NOCLIP | DT_EDITCONTROL);
+	DrawText(hdc, wc_details.c_str(), -1, &blockers_list_rect, DT_CALCRECT | DT_NOCLIP | DT_EDITCONTROL);
 
 	ReleaseDC(frame, hdc);
 	SelectObject(hdc, hfontOld);
@@ -804,7 +861,7 @@ bool callbacks_impl::prompt_user(const char *pVersion)
 	repostionUI();
 
 	SetWindowTextW(progress_label, wc_label.c_str());
-	SetWindowTextW(blockers_list, wc_version.c_str());
+	SetWindowTextW(blockers_list, wc_details.c_str());
 	SetWindowTextW(continue_button, update_btn_label.c_str());
 	SetWindowTextW(cancel_button, remind_btn_label.c_str());
 
@@ -1032,7 +1089,7 @@ extern "C" int wWinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPWSTR lpC
 		return 0;
 	}
 
-	if (!cb_impl.prompt_user(params.version.c_str())) {
+	if (!cb_impl.prompt_user(params.version.c_str(), params.details.c_str())) {
 		handle_exit();
 		return 1;
 	}

--- a/src/update-parameters.hpp
+++ b/src/update-parameters.hpp
@@ -25,6 +25,7 @@ struct update_parameters {
 	bool interactive = true;
 	bool restart_on_fail = false;
 	bool enable_removing_old_files = false;
+	std::string details;
 
 	~update_parameters()
 	{

--- a/src/update-parameters.hpp
+++ b/src/update-parameters.hpp
@@ -25,7 +25,6 @@ struct update_parameters {
 	bool interactive = true;
 	bool restart_on_fail = false;
 	bool enable_removing_old_files = false;
-	std::string details;
 
 	~update_parameters()
 	{


### PR DESCRIPTION
If on an older version of Desktop, simply display a version number of the new version available. If Desktop sends the 'details' parameter, display that to the user. 

Also, handle sizing/positioning if affected by the amount of text being displayed. 