### PR TITLE
Potential fix for code scanning alert no. 13: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -1,6 +1,8 @@
 permissions:
   contents: read
 name: Clang Format Check
+permissions:
+  contents: read
 
 on:
   push:

--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -1,8 +1,6 @@
 permissions:
   contents: read
 name: Clang Format Check
-permissions:
-  contents: read
 
 on:
   push:

--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: Clang Format Check
 
 on:


### PR DESCRIPTION
Potential fix for [https://github.com/streamlabs/a-files-updater/security/code-scanning/13](https://github.com/streamlabs/a-files-updater/security/code-scanning/13)

To fix the problem, add a `permissions` block to the workflow to restrict the GITHUB_TOKEN to the least privilege required. Since the workflow only checks out code and runs formatting checks, it does not require write access to repository contents, issues, or pull requests. The minimal permission required is `contents: read`. This block should be added at the root level of the workflow (above `jobs:`) to apply to all jobs, unless a job requires more specific permissions. Edit the `.github/workflows/clang-format.yml` file to insert the following block after the `name:` declaration and before the `on:` block:

```yaml
permissions:
  contents: read
```

No additional imports or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
